### PR TITLE
Monkey patch Promise lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 # promise-cache-throttle
 Provides caching and throttling of promises.
 
-- **cachify**(func, options) - Returns the function wrapped with caching
-- **cachifyAll**(target, options) - Patches all the target's methods with caching
-- **throttlify**(func, options) - Returns the function wrapped with throttling
-- **throttlifyAll**(target, options) - Patches all the target's methods with throttling
+- **Promise.cachify**(func, options) - Returns the function wrapped with caching
+- **Promise.cachifyAll**(target, options) - Patches all the target's methods with caching
+- **Promise.throttlify**(func, options) - Returns the function wrapped with throttling
+- **Promise.throttlifyAll**(target, options) - Patches all the target's methods with throttling
 
 These have similar definitions to bluebird's promisify:
 - cachify and throttlify resemble [bluebird's promisify](http://bluebirdjs.com/docs/api/promise.promisify.html)
@@ -21,8 +21,8 @@ You can also use the underlying functions directly:
 npm install promise-cache-throttle
 ```
 ```javascript
-var cacheThrottle = require('promise-cache-throttle');
 var Promise = require('bluebird');
+require('promise-cache-throttle')(Promise);
 var superagent = require('superagent');
 var agent = require('superagent-promise')(superagent, Promise);
 
@@ -38,7 +38,7 @@ var API = {
 	}
 };
 
-cacheThrottle.throttlifyAll(API, /* optional */ {
+Promise.throttlifyAll(API, /* optional */ {
 	concurrency: 1,
 	queueLimit: 100,
 	suffix: 'Throttled', // or leave empty to override methods
@@ -46,7 +46,7 @@ cacheThrottle.throttlifyAll(API, /* optional */ {
 		return _.includes(['getUsersAsync', 'getDriversAsync'], name);
 	}
 });
-cacheThrottle.cachifyAll(API, /* optional */ {
+Promise.cachifyAll(API, /* optional */ {
 	suffix: 'Cached', // or leave empty to override methods,
 	filter: function(name, func, target, passesDefaultFilter) { // optional filter
 		return _.includes(['getUsersAsync', 'getDriversAsync'], name);
@@ -56,24 +56,24 @@ cacheThrottle.cachifyAll(API, /* optional */ {
 ```
 Or for single functions:
 ```javascript
-var getDriversAsyncThrottled = cacheThrottle.throttlify(API.getDriversAsync, /* optional */ {context: API});
-var getDriversAsyncCached = cacheThrottle.cachify(API.getDriversAsync, /* optional */  {context: API});
+var getDriversAsyncThrottled = Promise.throttlify(API.getDriversAsync, /* optional */ {context: API});
+var getDriversAsyncCached = Promise.cachify(API.getDriversAsync, /* optional */  {context: API});
 ```
 To apply throttlify with the same throttler:
 ```javascript
-var throttler = new cacheThrottle.Throttler(/* optional */ {
+var throttler = new Promise.Throttler(/* optional */ {
 	concurrency: 1,
 	queueLimit: 100
 });
-var getDriversAsyncThrottled = cacheThrottle.throttlify(API.getDriversAsync, {
+var getDriversAsyncThrottled = Promise.throttlify(API.getDriversAsync, {
 	context: API,
 	throttler: throttler
 });
-var getUsersAsyncThrottled = cacheThrottle.throttlify(API.getUsersAsync, {
+var getUsersAsyncThrottled = Promise.throttlify(API.getUsersAsync, {
 	context: API,
 	throttler: throttler
 });
-cacheThrottle.throttlifyAll(API, /* optional */ {
+Promise.throttlifyAll(API, /* optional */ {
     throttler: throttler,
     filter: function(name, func, target, passesDefaultFilter) { // optional filter
         return name === 'getDriverAsync';
@@ -82,11 +82,11 @@ cacheThrottle.throttlifyAll(API, /* optional */ {
 ```
 Or use `LockableCache` and `Throttler` directly:
 ```javascript
-var throttler = new cacheThrottle.Throttler(/* optional */ {
+var throttler = new Promise.Throttler(/* optional */ {
 	concurrency: 1,
 	queueLimit: 100
 });
-var lockableCache = new cacheThrottle.LockableCache();
+var lockableCache = new Promise.LockableCache();
 
 lockableCache.callAsync('users', function() {
 	return throttler.throttleAsync(function() {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ var getDriversAsyncCached = Promise.cachify(API.getDriversAsync, /* optional */ 
 ```
 To apply throttlify with the same throttler:
 ```javascript
-var throttler = new Promise.Throttler(/* optional */ {
+var throttler = new Promise.throttlify.Throttler(/* optional */ {
 	concurrency: 1,
 	queueLimit: 100
 });
@@ -82,11 +82,11 @@ Promise.throttlifyAll(API, /* optional */ {
 ```
 Or use `LockableCache` and `Throttler` directly:
 ```javascript
-var throttler = new Promise.Throttler(/* optional */ {
+var throttler = new Promise.throttlify.Throttler(/* optional */ {
 	concurrency: 1,
 	queueLimit: 100
 });
-var lockableCache = new Promise.LockableCache();
+var lockableCache = new Promise.cachify.LockableCache();
 
 lockableCache.callAsync('users', function() {
 	return throttler.throttleAsync(function() {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var _ = require('@dispatcher/underscore-ext');
 
-var index = {};
-_.extend(index, require('./lib/cachify'));
-_.extend(index, require('./lib/throttlify'));
-
-module.exports = index;
+module.exports = function(Promise) {
+	_.extend(Promise, require('./lib/cachify'));
+	_.extend(Promise, require('./lib/throttlify'));
+	return Promise;
+};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,16 @@
 var _ = require('lodash');
 
 module.exports = function(Promise) {
-	_.extend(Promise, require('./lib/cachify'));
-	_.extend(Promise, require('./lib/throttlify'));
-	return Promise;
+	var index = {};
+	_.extend(index, require('./lib/cachify'));
+	_.extend(index, require('./lib/throttlify'));
+
+	if (Promise === undefined) {
+		// For backward compatibility in v1.x
+		return index;
+	} else {
+		// Monkey-patch Promise
+		_.extend(Promise, index);
+		return Promise;
+	}
 };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var _ = require('@dispatcher/underscore-ext');
+var _ = require('lodash');
 
 module.exports = function(Promise) {
 	_.extend(Promise, require('./lib/cachify'));

--- a/lib/cachify.js
+++ b/lib/cachify.js
@@ -53,6 +53,6 @@ function cachifyAll(target, options) {
 	return target;
 };
 
-module.exports.LockableCache = LockableCache;
 module.exports.cachify = cachify;
 module.exports.cachifyAll = cachifyAll;
+module.exports.cachify.LockableCache = LockableCache;

--- a/lib/throttlify.js
+++ b/lib/throttlify.js
@@ -52,6 +52,7 @@ function throttlifyAll(target, options) {
 	return target;
 }
 
-module.exports.Throttler = Throttler;
 module.exports.throttlify = throttlify;
 module.exports.throttlifyAll = throttlifyAll;
+module.exports.throttlify.Throttler = Throttler;
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promise-cache-throttle",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Provides function caching and throttling.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Reference: https://github.com/DispatcherInc/promise-cache-throttle/issues/7

e.g.:
```javascript
var Promise = require('bluebird');
require('promise-cache-throttle')(Promise);
/*
Which gives us:
Promise.cachify
Promise.cachifyAll
Promise.throttlify
Promise.throttlifyAll
*/
```

Ideally, we should remove the dependency on bluebird in LockableCache and Throttler and use the one that's given to us.